### PR TITLE
Fixed cards displaying incorrectly

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -104,7 +104,7 @@ const Main = (props) => {
         <div className="masthead-image" id="master-container">
           <Card>
             {[...new Array(CARD)].map((_, i) => (
-              <MainCard key={i} />
+              <MainCard idx={i} />
             ))}
           </Card>
         </div>

--- a/src/MainCard.js
+++ b/src/MainCard.js
@@ -2,7 +2,7 @@ import React from "react";
 import "./Card.css";
 import AuthContext from "./auth-context";
 
-const MainCard = () => (
+const MainCard = ({ idx }) => (
   <AuthContext.Consumer>
     {(ctx) => (
       <>
@@ -52,7 +52,7 @@ const MainCard = () => (
               </p>
             </div>
           );
-        })}
+        }).filter((_, index) => index === idx)}
       </>
     )}
   </AuthContext.Consumer>


### PR DESCRIPTION
Fixes #1 

The issue was simple, you were essentially returning every single card from `MainCard` and in `Main` you were iterating over `MainCard` n times, essentially producing n cards vertically and then n lots of those, meaning you got n*n cards and in a strange styling.

The codebase may require further restructuring as I do not think using the `children` prop is particularly good practice, but regardless it works. 👍 